### PR TITLE
Parse modified files

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,3 +2,4 @@ const { protect } = require("./src/protect");
 
 // test
 protect("ABCDEF");
+protect(123456);

--- a/pre-commit
+++ b/pre-commit
@@ -1,4 +1,16 @@
+#!/bin/bash
 echo "Evaluating pre-commit rules..."
 secrets=$(cat secrets.json | jq '.secrets')
 echo "From secrets.json: $secrets"
+
+#TODO: fix added files not being found (only modified are being found)
+echo "Modified files: "
+files=$(git diff --name-only --diff-filter=ACM -z | xargs -0)
+files_arr=($(echo "$files" | tr ' ' '\n'))
+for file in "${files_arr[@]}"
+do
+    : 
+    echo $file
+done
+
 #TODO: add logic that hides secrets prior to commit

--- a/pre-commit
+++ b/pre-commit
@@ -1,15 +1,22 @@
 #!/bin/bash
 echo "Evaluating pre-commit rules..."
-secrets=$(cat secrets.json | jq '.secrets')
-echo "From secrets.json: $secrets"
 
-echo "Staged files: "
+# generate list of staged files
 files=$(git diff --staged --name-only --diff-filter=ACM -z | xargs -0)
 files_arr=($(echo "$files" | tr ' ' '\n'))
-for file in "${files_arr[@]}"
-do
-    : 
-    echo $file
-done
 
-#TODO: add logic that hides secrets prior to commit
+# iterate through list of secrets in secrets.json
+secrets=$(cat secrets.json | jq -c '.secrets')
+for secret in $(echo "${secrets}" | jq -r '.[] | @base64'); do
+    _jq() {
+     echo ${secret} | base64 --decode | jq -r ${1}
+    }
+    secret_msg=$(_jq '.msg')
+    secret_hash=$(_jq '.id')
+    # scan each staged file for usages of secret
+    for file in "${files_arr[@]}"; do
+        echo "Checking $file for $secret_hash"
+        # replace found secret with hash
+        sed -i '' "s/$secret_msg/$secret_hash/g" $file
+    done
+done

--- a/pre-commit
+++ b/pre-commit
@@ -3,9 +3,8 @@ echo "Evaluating pre-commit rules..."
 secrets=$(cat secrets.json | jq '.secrets')
 echo "From secrets.json: $secrets"
 
-#TODO: fix added files not being found (only modified are being found)
-echo "Modified files: "
-files=$(git diff --name-only --diff-filter=ACM -z | xargs -0)
+echo "Staged files: "
+files=$(git diff --staged --name-only --diff-filter=ACM -z | xargs -0)
 files_arr=($(echo "$files" | tr ' ' '\n'))
 for file in "${files_arr[@]}"
 do


### PR DESCRIPTION
Pre-commit checks all new and modified files for secrects and secrets.json and replaces them with their corresponding hash values.
To test this functionality:
- run `node index.js` to protect a few secret values
- create a new file and write one of the protected secrets somewhere in the file
- stage the new file (`git add`)
- Run the pre-commit hook `./pre-commit`
- Observe the file has changed, and the hash has replaced the secret